### PR TITLE
Fixed spelling mistakes, added example and changed some examples.

### DIFF
--- a/docstrings/numerical_simulation/environment.yaml
+++ b/docstrings/numerical_simulation/environment.yaml
@@ -369,7 +369,7 @@ classes:
 
         returns:
           type: np.ndarray # [py]
-          type: Eigen::Matrix3d # [coo]
+          type: Eigen::Matrix3d # [cpp]
           description: Rotation matrix :math:`\mathbf{R}^{B/A}` from frame :math:`A` to frame `B`
 
       - name: getAngle                           # [cpp]
@@ -393,7 +393,35 @@ classes:
           type: float # [py]
           type: double # [py]
           description: Value of requested angle
-          
+##################################################################
+  - name: RotationalEphemeris
+    short_summary: |
+      Object that stores the rotational state of the bodies.
+    extended_summary: |
+      Object that stores the rotational state of the bodies. This object can be used to calculate rotation matrices,
+      which are used to transform coordinates between reference frames.
+
+    methods:
+      - name: getRotationMatrixToBaseFrame                          # [cpp]
+      - name: body_fixed_to_inertial_rotation                       # [py]
+        short_summary: |
+          Function to get rotation matrix from target frame to base frame over time.
+        extended_summary: |
+          Function to get rotation matrix from target frame to base frame at a certain epoch. It is used to
+          transform a Cartesian state vector including position and velocity from a body fixed to inertial frame.
+
+        parameters:
+          - name: secondsSinceEpoch # [cpp]
+            type: float # [cpp]
+          - name: current_time # [py]
+            type: float # [py]
+            description: |
+              The time at which the rotation matrix is evaluated
+
+        returns:
+          type: np.ndarray # [py]
+          type: Eigen::Matrix3d # [cpp]
+          description: Rotation matrix :math:`\mathbf{R}^{B/A}` from frame :math:`A` to frame `B`
 ##################################################################
      
   - name: VehicleSystems

--- a/docstrings/numerical_simulation/environment_setup/ephemeris.yaml
+++ b/docstrings/numerical_simulation/environment_setup/ephemeris.yaml
@@ -710,7 +710,7 @@ functions:
     short_summary: "Factory function for creating approximate ephemeris model settings for major planets."
     extended_summary: |
       Factory function for settings object, defining approximate ephemeris model for major planets.
-      In this highly simplified ephemeris model, Keplerian elements of the major solar system bodies are modelled as linear functions of time and several sinusoidal variations (described `this document <https://ssd.jpl.nasa.gov/planets/approx_pos.html>`_).
+      In this highly simplified ephemeris model, Keplerian elements of the major solar system bodies are modelled as linear functions of time and several sinusoidal variations (described in `this document <https://ssd.jpl.nasa.gov/planets/approx_pos.html>`_).
       Note that this option is only available for solar system planets. For the case of the Earth the approximate ephemeris of the Earth-Moon barycenter is returned.
 
     parameters:
@@ -744,7 +744,11 @@ functions:
          # create ephemeris settings (normally used for Jupiter) and add to body settings of body "CustomBody" # [py]
          body_settings.get( "CustomBody" ).ephemeris_settings = environment_setup.ephemeris.approximate_jpl_model( "Jupiter" ) # [py]
 
- 
+      .. code-block:: cpp # [cpp]
+         # [cpp]
+         // create ephemeris settings and add to body settings of body "Jupiter" # [cpp]
+         bodySettings[ "CustomBody" ]->ephemerisSettings = std::make_shared< ApproximatePlanetPositionSettings >(   # [cpp]
+         							ephemerides::ApproximatePlanetPositionsBase::jupiter, false );   
 
   #######################################################################
 
@@ -784,7 +788,7 @@ functions:
       .. code-block:: python # [py]
          # [py]
          # Define the constant cartesian state # [py]
-         constant_cartesian_state = [747.13e9, 0, 0, 13.5e3, 0, 0] # [py]
+         constant_cartesian_state = [100.0e9, 100.0e9, 100.0e9, 10.0e3, 10.0e3, 10.0e3] # [py]
          # Define the ephemeris frame # [py]
          frame_origin = "SSB" # [py]
          frame_orientation = "J2000" # [py]
@@ -802,7 +806,7 @@ functions:
     short_summary: "Factory function for creating custom ephemeris model settings."
     extended_summary: |
       Factory function for settings object, defining ephemeris model with a custom state.
-      This allows the user to provide an custom state function as ephemeris model.
+      This allows the user to provide a custom state function as ephemeris model.
 
     parameters:
       - name: custom_state_function # [py]
@@ -930,7 +934,7 @@ functions:
       .. code-block:: python # [py]
         # [py]
         # Define the computation of the Kepler orbit ephemeris # [py]
-        initial_state_in_keplerian_elements = [747.13e9, 0, 0, 13.5e3, 0, 0] # [py]
+        initial_state_in_keplerian_elements = [100e9, 0.7, 1.0, 2.0, 2.0, 2.0] # [py]
         initial_state_epoch = 12345 # [py]
         central_body_gravitational_parameter = 1.3284e20 # (sum of Sun and Jupiter) # [py]
         # Define the ephemeris frame # [py]
@@ -1119,7 +1123,7 @@ functions:
        
         
     examples: |
-      In this example, we create ephemeris settings for Jupiter, by scaling an existing :class:`~tudatpy.numerical_simulation.environment_setup.ephemeris.EphemerisSettingsObject` with a the constant elements of a vector:
+      In this example, we create ephemeris settings for Jupiter, by scaling an existing :class:`~tudatpy.numerical_simulation.environment_setup.ephemeris.EphemerisSettingsObject` with the constant elements of a vector:
 
       .. code-block:: python # [py]
         # [py]


### PR DESCRIPTION
**In ephemeris:**
Fixed spelling mistakes.  

Tried adding the custom body example to the approximate_jpl_model() function by adding a cpp code block below the python code block. Check whether this works correctly in the API.  

Changed Cartesian state and Keplerian state in constant() and keplerian() examples, to make more sense.

**In environment**
Added RotationalEphemeris class and the corresponding body_fixed_to_inertial_rotation function. If this works correctly and the pull request is accepted, I can add the other functions corresponding to RotationalEphemeris.