### PR TITLE
adjustment to environment yaml to assign correct package versions

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - sofa-cmake
   - cspice-cmake
   - nrlmsise-00
-  - python=3.9
+  - python == 3.9
   - pybind11
   - pybind11-abi
   - numpy
@@ -22,7 +22,7 @@ dependencies:
   # Other doc related
   - jinja2
   - pyyaml
-  - pydantic=1.10.9
+  - pydantic == 1.10.9
   - numpydoc
   - doxygen # for cpp api
   - pip


### PR DESCRIPTION
I tried to build the tudat API locally on my pc, but it initially failed during the documenting step (python cli d). The error was related to the pydantic package and the parsing setup. 

Specifically, in the environment.yaml, the versions of the packages are not properly assigned (for pydantic and python). As a result, a pydantic package > V2.0 is used that changes the functionality of Optional[ ]. Since V2.0, Optional[str] is treated as a required field but allowed to have None as its value. Hence, the docstrings and models.py (located in tudat-multidoc\multidoc\multidoc\parsing) do not function as desired.  

I corrected the environment.yaml so that the pydantic (and python) versions are properly assigned. After this change, I was succesfully able to document, build, and generate the sphynx html files for the API by following the readme instructions.

If we want to use the most up-to-date version of pydantic, we would need to change the usage of Optional[ ] in models.py. Instructions on how to do this and more background info can be found in https://stackoverflow.com/questions/76690463/pydantic-2-0-ignores-optional-in-schema-and-requires-the-field-to-be-available.