### PR TITLE
Move Environment Models point of attention to the respective places

### DIFF
--- a/docstrings/numerical_simulation/environment_setup/ephemeris.yaml
+++ b/docstrings/numerical_simulation/environment_setup/ephemeris.yaml
@@ -10,8 +10,40 @@
 
 extended_summary: |
   This module contains a set of factory functions for setting up the
-  ephemeris models of celestial bodies in an environment.
+  ephemeris models of celestial bodies in an environment. Below a short
+  overview of aspects of some of the ephemeris models in order to aid in
+  properly selecting an choosing a model.
 
+  **Spice-based models** For many typical applications, natural body ephemerides 
+  will be calculated from `Spice kernels <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/default_env_models.html#spice-in-tudat>`_. 
+  In some cases, a user may find that the default Spice kernels are insufficient 
+  for their purposes, due to one of two reasons:
+
+  * The body for which the state is required *is* in the ephemeris Spice kernel, but the time at which the state is needed lies outside of the bounds for which the Spice kernel has data
+  * The body for which the state is required *is not* in the ephemeris Spice kernel
+
+  In both cases, a user should load additional Spice kernels. This can be done using the :func:`~tudatpy.interface.spice.load_kernel`. Spice kernels for many bodies may be found in a number of places.
+  The 'goto' place for Spice kernels for ephemerides is the NAIF website (developers of Spice), which you can find
+  `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/>`_.
+
+  **Use of scaled models** For a sensitivity analysis (among others) it may be useful to modify the ephemeris of a body, for instance
+  to emulate the influence of a 1 km offset in the state provided by the nominal ephemeris. Unlike most other environment models,
+  this cannot be achieved (at least not for most types of ephemerides) by modifying a single defining parameter of the model.
+  Instead, we provide the functions
+  :func:`~tudatpy.numerical_simulation.environment_setup.ephemeris.scaled_by_vector` and
+  :func:`~tudatpy.numerical_simulation.environment_setup.ephemeris.scaled_by_vector_function`,
+  which take nominal ephemeris settings, and add a user-defined variation (constant or time-varying; absolute or relative) to the
+  inertial Cartesian state elements produced by the ephemeris.
+
+  **Using the ephemeris outside the propagation** In various cases, the ephemeris object is useful to use independently of the propagation. Details can be found in the API entry for :class:`~tudatpy.numerical_simulation.environment.Ephemeris`, but we provide a short example here as well.
+
+  .. code-block:: python
+
+    bodies = .... // Create system of bodies
+    earth_ephemeris = bodies.get('Earth').ephemeris
+    earth_state_at_epoch = earth_ephemeris.cartesian_state( epoch )
+
+  where the ``epoch`` input is (as always in Tudat) the time in seconds since J2000. The ``earth_state_at_epoch`` is always in a frame with inertial orientation. The specific orientation and origin can be access from the :attr:`~tudatpy.numerical_simulation.environment.Ephemeris.frame_orientation` and :attr:`~tudatpy.numerical_simulation.environment.Ephemeris.frame_origin` attributes.
 
 #########################################################################
 #  ███████ ███   ██ ██    ██ ███    ███  ██████

--- a/docstrings/numerical_simulation/environment_setup/gravity_field.yaml
+++ b/docstrings/numerical_simulation/environment_setup/gravity_field.yaml
@@ -9,7 +9,19 @@
 
 extended_summary: |
   This module contains a set of factory functions for setting up the
-  gravitational potential models of celestial bodies in an environment.
+  gravitational potential models of celestial bodies in an environment. Below a short
+  overview of aspects of some of the gravity field models in order to aid in
+  properly selecting an choosing a model.
+  Unlike most other environment model options in Tudat, there are multiple options for creating either a spherical harmonic gravity field, and a point mass gravity field:
+
+  * Point-mass gravity field: defining the gravitational parameter manually (:func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.central`) or requiring the gravitational parameter to be extracted from Spice (:func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.central_spice`).
+  * Spherical harmonic gravity field: defining all the settings manually (:func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.spherical_harmonic`), loading a pre-defined model for a solar system body (:func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.from_file_spherical_harmonic`) or calculating the spherical harmonic coefficients (up to a given degree) based on an ellipsoidal homogeneous mass distribution (:func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.spherical_harmonic_triaxial_body`)
+
+  Rigid body properties will always be created automatically when a body is endowed with a gravity field, as described below:
+
+  * Point-mass gravity field: mass computed from gravitational parameter; zero inertia tensor, and center of mass at origin of body-fixed frame
+  * Spherical harmonic gravity field: mass computed from gravitational parameter, center of mass computed from degree 1 gravity field coefficients, inertia tensor as described in :func:`~tudatpy.numerical_simulation.environment_setup.gravity_field.spherical_harmonic`
+  * Polyhedron gravity field: mass computed from gravitational parameter, center of mass and inertia tensor computed from homogeneous mas distribution inside body
 
 references: |
   .. [1] Balmino, G. (1994). Gravitational potential harmonics from the shape of an homogeneous body. Celestial
@@ -524,7 +536,19 @@ functions:
       .. math::
          U(\mathbf{r})=\sum_{l=0}^{l_{max}}\sum_{m=0}^{l}\mu\left(\frac{{R}^{l}}{r^{l+1}}\right)\bar{P}_{lm}(\sin\phi)\left(\bar{C}_{lm}\cos m\theta+\bar{S}_{lm}\sin m\theta\right)
 
-      with :math:`\mathbf{r}` the position vector of the evaluation point, measured from the body's center of mass. The angles :math:`\phi` and :math:`\theta` are the body-fixed latitude and longitude of the evaluation point, :math:`\bar{P}_{lm}` is the associated Legendre polynomial (at degree/order :math:`l/m`) and :math:`\bar{C}_{lm}` and :math:`\bar{S}_{lm}` are the associated normalized spherical harmonic coefficients.
+      with :math:`\mathbf{r}` the position vector of the evaluation point, measured from the body's center of mass. The angles :math:`\phi` and :math:`\theta` are the body-fixed latitude and longitude of the evaluation point, and :math:`\bar{P}_{lm}` is the associated Legendre polynomial (at degree/order :math:`l/m`).
+
+      For the spherical harmonic gravity field (including other spherical harmonic functions), the normalized mean moment of inertia must be set by the user, to allow an inertia tensor to be computed. This is done using the :attr:`~tudatpy.numerical_simulation.environment_setup.gravity_field.SphericalHarmonicsGravityFieldSettings.scaled_mean_moment_of_inertia` attribute of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field.SphericalHarmonicsGravityFieldSettings` class, as in the example below
+
+      .. code-block:: python # [py]
+
+        # Add gravity field model settings to body of spherical harmonic type # [py]
+        body_settings.get( "Mars" ).gravity_field = ... # [py]
+
+        # Add setting for moment of inertia # [py]
+        body_settings.get( "Mars" ).gravity_field.scaled_mean_moment_of_inertia = 0.365 # [py]
+             
+      This code snippet will automatically create a rigid body properties for Mars, with the inertia tensor computed from this value of 0.365 and the degree 2 gravity field coefficients. Note that, if gravity field variations are used for the body, time-variability of the degree 1- and 2- coefficients will be reflected in time-variability of the body's center of mass and inertia tensor.
 
       Note: Spherical harmonic coefficients used for this environment model must *always* be fully normalized.
       To normalize un-normalized spherical harmonic coefficients, see :func:`~tudatpy.astro.gravitation.normalize_spherical_harmonic_coefficients`.
@@ -853,7 +877,10 @@ functions:
       to Werner and Scheeres [2]_.
 
       This function uses the gravitational parameter to define the gravity field. To instead use the density 
-      constant see :func:`~tudatpy.astro.gravitation.polyhedron_from_density`.
+      constant see :func:`~tudatpy.astro.gravitation.polyhedron_from_density`. Since both models tend to be computationally intensive, 
+      it is recommended to use polyhedra with the lowest number of facets that allows meeting the desired accuracy. The number of facets of a polyhedron
+      model can be reduced using any mesh processing software, for example `PyMeshLab <https://pymeshlab.readthedocs.io/en/latest/>`_.
+      Additionally, different functions to process a polyhedron are available in `Polyhedron utilities <https://py.api.tudat.space/en/latest/polyhedron_utilities.html>`_.
 
     parameters:
       - name: gravitational_parameter # [py]

--- a/docstrings/numerical_simulation/environment_setup/ground_station.yaml
+++ b/docstrings/numerical_simulation/environment_setup/ground_station.yaml
@@ -11,7 +11,40 @@ extended_summary: |
   stations and associated models. Note that in Tudat, no distinction is
   made between a ground station/lander on Earth or a different body. 
   A ground station defines a reference point (and other relevant properties)
-  on a celestial body.
+  on a celestial body. Although ground stations are considered part of the 
+  environment in Tudat (as properties of a ``Body`` object), they do not 
+  influence the numerical propagation (unless a custom model imposing this 
+  is implemented by the user). Ground stations can be defined through the 
+  ``BodySettings`` as any other model. But, as the rest of the environment 
+  does not depend on them, they can safely be added to a body after it is 
+  created. The process is similar to the one described for :ref:`decorate_empty_body`. 
+  Specifically, ground station settings are created, and these are then used 
+  to create a ground station and add it to the body. The specifics of creating
+  ground station settings is described 
+  `in the API documentation <https://py.api.tudat.space/en/latest/ground_stations.html>`_. 
+  An example is given below:
+
+  .. code-block:: python # [py]
+
+    # Create ground station settings # [py]
+    ground_station_settings = environment_setup.ground_station.basic_station( # [py]
+        "TrackingStation", # [py]
+        [station_altitude, delft_latitude, delft_longitude], # [py]
+        element_conversion.geodetic_position_type) # [py]
+
+    # Add the ground station to the environment # [py]
+    environment_setup.add_ground_station( # [py]
+        bodies.get_body("Earth"), # [py]
+        ground_station_settings ) # [py]
+
+  
+  where a simple ground station is created (with only a name and a position), with its position defined in geodetic elements. The position of a ground station in a body-fixed frame can have two sources of time-variability:
+
+  * From `shape deformation models <https://py.api.tudat.space/en/latest/shape_deformation.html>`_ of the body on which it is located
+  * From a list of :class:`~tudatpy.numerical_simulation.environment_setup.ground_station.GroundStationMotionSettings` objects, which can be assigned to the ground station settings (see e.g. :func:`~tudatpy.numerical_simulation.environment_setup.ground_station.basic_station`). These models define time-variability of individual ground stations, in addition to the global shape deformation.
+
+  To automatically create a list of settings for all DSN stations (which are then typically assigned to the ``ground_station_settings`` of Earth), the :func:`~tudatpy.numerical_simulation.environment_setup.ground_station.dsn_station_settings` can be used.
+
 
 #########################################################################
 #  ███████ ███   ██ ██    ██ ███    ███  ██████

--- a/docstrings/numerical_simulation/environment_setup/rotation_model.yaml
+++ b/docstrings/numerical_simulation/environment_setup/rotation_model.yaml
@@ -9,8 +9,41 @@
 
 extended_summary: |
   This module contains a set of factory functions for setting up the
-  rotation models of celestial bodies in an environment.
+  rotation models of celestial bodies in an environment. Below a short
+  overview of aspects of some of the rotation models in order to aid in
+  properly selecting an choosing a model.
 
+  Tudat has a broad range of rotation models available. In principle, these models can be assigned to both celestial bodies and natural bodies. 
+  However, a subset of these models is typically only applied to natural *or* artificial bodies. Rotation models have a wide range of,
+  sometimes indirect, influences on the dynamics
+  
+  * A spherical harmonic acceleration exerted by a central body is first evaluated in a body-fixed frame, and the transformed to an inertial frame. Consequently, the central body's rotation has a fundamental influence on the exerted spherical harmonic acceleration
+  * A `thrust acceleration <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/thrust_models.html#thrust-models>`_ in Tudat is calculated from two models: (1) an engine model, which defined the body-fixed direction of the thrust, and the magnitude of the thrust (2) the orientation of the body in space, defined by its rotation model
+  * For a non-spherical central body shape models, the current orientation of this central body has an indirect influence on the altitude at which a vehicle with a given *inertial* state is located
+
+  **Rotation and thrust** Two rotation models, which are typically used for vehicles under `thrust <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/thrust_models.html#thrust-models>`_, and/or vehicles undergoing `aerodynamic forces <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/aerodynamics.html#aerodynamic-models>`_, are the following:
+
+  * The rotation model :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.aerodynamic_angle_based`, which calculates the body's rotation based on the angle of attack, sideslip angle and bank angle. Note that these angles are definend w.r.t. the relative wind. This model is typical when using, for instance, a re-entry simulation. It imposes these three angles, and calculates the body orientation by combination with the latitude, longitude, heading angle, flight path angles. There is a related model, :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.zero_pitch_moment_aerodynamic_angle_based`, that uses the same setup, but does not impose the angle of attack, but caculates by imposing aerodynamic pitch trim (zero pitch moment).
+  * The rotation model :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.custom_inertial_direction_based`, which is typical when calculating dynamics of a vehicle under thrust. It is based on linking a body-fixed  direction (now limited to the body-fixed x-axis) to an arbitrary inertial direction. This allows the thrust (assuming that this is aligned with this same body-fixed direction) to be guided in an inertial direction determined by a user-defined model. 
+
+  **Relation to gravity field** When modifying the rotation model settings, the name of the body-fixed frame may also be changed (as is the case for, for instance, the :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.gcrs_to_itrs`, where the body-fixed frame has the name "ITRS").
+  One consequence of this is that you may get an error from the spherical harmonic gravity field, which can no longer find the frame to which it is associated. This can be resolved by (for instance) associating the gravity field to the new frame. For the above example, this would be done by the following:
+
+  .. code-block:: python
+                  
+      body_settings.get( "Earth" ).gravity_field_settings.associated_reference_frame = "ITRS"
+      
+  **High-accuracy Earth rotation model** The :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.gcrs_to_itrs` creates a high accuracy rotation model, following the IERS 2010 Conventions. This includes small variations that are not predicted by models, but are instead measured by geodetic techniques and published as tabulated data by the IERS. If so desired, the exact files used for these corrections may be adapted by the user (see :func:`~tudatpy.astro.earth_orientation.EarthOrientationAnglesCalculator`), which includes specific settings for daily variations in earth rotation angle, which influences the UTC - UT1 time conversion. 
+
+  **Using the rotation model outside the propagation** In various cases, the rotation model object is useful to use independently of the propagation. Details can be found in the API entry for :class:`~tudatpy.numerical_simulation.environment.RotationalEphemeris`, but we provide a short example here as well.
+
+  .. code-block:: python
+
+      bodies = .... // Create system of bodies
+      earth_rotation_model = bodies.get('Earth').rotation_model
+      earth_rotation_at_epoch = earth_rotation_model.body_fixed_to_inertial_rotation( epoch )
+
+  where the ``epoch`` input is (as always in Tudat) the time in seconds since J2000. The specific rotation model provides the orientation from the :attr:`~tudatpy.numerical_simulation.environment.RotationalEphemeris.inertial_frame_name` to the :attr:`~tudatpy.numerical_simulation.environment.RotationalEphemeris.body_fixed_frame_name` frames. In the above example, the rotation matrix from the body-fixed to the inertial frame is extracted. Other functions are available in the :class:`~tudatpy.numerical_simulation.environment.RotationalEphemeris` to extract the inverse rotation, its time-derivative, and the angular velocity vector of the body-fixed frame. Finally, note that the :func:`~tudatpy.numerical_simulation.environment.transform_to_inertial_orientation`, which uses the rotation model to rotation a body-fixed to an inertial state, may be useful in this context for some applications.
 
 #########################################################################
 #  ███████ ███   ██ ██    ██ ███    ███  ██████

--- a/docstrings/numerical_simulation/environment_setup/vehicle_systems.yaml
+++ b/docstrings/numerical_simulation/environment_setup/vehicle_systems.yaml
@@ -8,7 +8,37 @@
 # Radiation Pressure Setup ( createBodyShapeModel.h )
 
 extended_summary: |
-  This module contains a set of factory functions for setting up physical and system properties of a vehicle
+  This module contains a set of factory functions for setting up physical and system properties of a vehicle.
+  For various high-accuracy models of non-conservative spacecraft dynamics, a so-called macromodel is required which defines
+  the external shape of the vehicle. This macromodel is typically defined by a set of panels, with each panel assigned
+  specific properties of how it interacts with the environment. At present, the spacecraft macromodel in Tudat is only
+  used for the calculation of a panelled radiation pressure acceleration, but future updates will also use it for the
+  calculation of aerodynamic coefficients in both rarefied and hypersonic flow.
+
+  The current panels in Tudat allow a list of panels to be defined, with the geometrical properties of panel :math:`i` defined by the
+  surface normal vector :math:`\hat{\mathbf{n}}_{i}` and the surface area :math:`A_{i}`. Note that, since the panel shape or
+  location is not yet defined, computing torques due to surface forces, or incorporating shadowing into the panel
+  force calculatuion, is not yet supported.
+
+  The panel surface normal may be defined in either the body-fixed frame :math:`\mathcal{B}` of the vehicle, or to a 'vehicle-part-fixed frame'
+  :math:`\mathcal{F}_{j}`. A 'vehicle part' is defined as a part of the vehicle that can move/rotate w.r.t. the body-fixed frame of the
+  spacecraft. Typical examples are the solar arrays and an movable antenna.
+
+  The panel surface normal (in either the body frame or the part frame), may be defined by the
+  :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.frame_fixed_panel_geometry`,
+  :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.time_varying_panel_geometry` or
+  :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.body_tracking_panel_geometry` functions,
+  where the latter is used to ensure that a panel normal automatically points to/away from another bodY (e.g. the Sun for solar panels).
+
+  A full panel is created by defining its geometry, and models for its interaction with the environment (currently limited to
+  a reflection law to compute the influence of radiation pressure) using the
+  :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.body_panel_settings` function.
+
+  The vehicle macromodel, and the rotation models from the body-fixed frame to the (optional) part-fixed frames are defined by
+  using the :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.full_panelled_body_settings` function, and
+  assigned to the ``vehicle_shape_settings`` attribute of the :class:`~tudatpy.numerical_simulation.environment_setup.BodySettings` class.
+  When a full macromodel is not available to the user, a 'box-wing' model may also be used, which creates the macromodel
+  bassed on user settings, using the :func:`~tudatpy.numerical_simulation.environment_setup.vehicle_systems.box_wing_panelled_body_settings` function.
 
 #########################################################################
 #  ███████ ███   ██ ██    ██ ███    ███  ██████


### PR DESCRIPTION
The points of attention in the Environment Models have been moved to the respective places in the API docs. Where I thought it was reasonable, I have left them out altogether. Please double check whether everything renders correctly, I had some issues with creating correct hyperlinks to functions in the rotation model API page.