### PR TITLE
Add exposed accelerations to API docs

### DIFF
--- a/docstrings/numerical_simulation/propagation_setup/acceleration.yaml
+++ b/docstrings/numerical_simulation/propagation_setup/acceleration.yaml
@@ -263,6 +263,21 @@ functions:
 #         // Add the acceleration to the map # [cpp]
 #         accelerationSettings["Vehicle"]["Earth"].push_back(std::make_shared< AccelerationSettings >( aerodynamic ) ); # [cpp]
 
+  # Radiation pressure
+  - name: radiationPressureAcceleration # [cpp]
+  - name: radiation_pressure # [py]
+    short_summary: "Creates settings for the radiation pressure acceleration."
+    extended_summary: |
+      Creates settings for the radiation pressure acceleration. This function takes the source model of the body exerting the acceleration, and the target model of the 
+      body undergoing the acceleration, and links these models to set up the specific acceleration model, regardless of how the source and target models are defined. 
+      For more extensive details on how this is done, check out the 
+      `radiation pressure acceleration page <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/radiation_pressure_acceleration.html>`_.
+
+
+    returns:
+        type: AccelerationSettings
+        description: Acceleration settings object.
+
     
   # Cannonball radiation pressure
   - name: cannonBallRadiationPressureAcceleration # [cpp]
@@ -293,7 +308,7 @@ functions:
          # [py]
          # Create acceleration dict # [py]
          accelerations_acting_on_vehicle = dict() # [py]
-         # Add aerodynamic acceleration exerted by Earth # [py]
+         # Add cannonball radiation pressure acceleration exerted by Sun # [py]
          accelerations_acting_on_vehicle["Sun"] = [propagation_setup.acceleration.cannonball_radiation_pressure()] # [py]
 
 #      .. code-block:: cpp # [cpp]
@@ -502,6 +517,29 @@ functions:
 #          maximumOrderOfGanymede,  # [cpp]
 #          maximumDegreeOfIo,  # [cpp]
 #          maximumOrderOfIo ) ); # [cpp]
+
+  # Polyhedron gravity
+  - name: polyhedronAcceleration # [cpp]
+  - name: polyhedron_gravity # [py]
+    short_summary: "Creates settings for the polyhedron gravity acceleration."
+    extended_summary: |
+      Creates settings for the polyhedron gravity acceleration, which follows from defining a body to have polyhedral gravity.
+
+    returns:
+        type: AccelerationSettings
+        description: Acceleration settings object.
+
+
+  # Ring gravity
+  - name: ringAcceleration # [cpp]
+  - name: ring_gravity # [py]
+    short_summary: "Creates settings for the ring gravity acceleration."
+    extended_summary: |
+      Creates settings for the ring gravity acceleration, which follows from defining a body to have ring gravity.
+
+    returns:
+        type: AccelerationSettings
+        description: Acceleration settings object.
 
 
   # Relativistic correction
@@ -720,13 +758,13 @@ functions:
              phase = np.pi * ( current_time - reference_time ) / period # [py]
              return np.array([1.0E-8, 0.0, 0.0]) * np.sin(phase) # [py]
          # [py]
-         acceleration_settings_on_vehicle["Vehicle"] = [propagation_setup.acceleration.custom( # [py]
+         acceleration_settings_on_vehicle["Vehicle"] = [propagation_setup.acceleration.custom_acceleration( # [py]
              custom_function)] # [py]
 
   # Direct tidal dissipation
   - name: directTidalDissipationAcceleration # [cpp]
   - name: direct_tidal_dissipation_acceleration # [py]
-    short_summary: "Creates settings for custom acceleration."
+    short_summary: "Creates settings for tidal acceleration."
     extended_summary: |
       Creates settings for tidal accelerations. The direct of tidal effects in a satellite system is applied directly as
       an acceleration (as opposed to a modification of spherical harmonic coefficients).
@@ -827,7 +865,7 @@ functions:
     examples: |
       In this example, we define an acceleration model to represent two quasi-impulsive shots, with a total duration of
       30 seconds, and a rise time of 5 seconds. The maneuvers are to be done at :math:`t=86400` and :math:`t=2*86400`.
-      The first maneuver is exclusively in :math:`x-`direction, and the second one exclusively in :math:`y-`direction,
+      The first maneuver is exclusively in :math:`x`-direction, and the second one exclusively in :math:`y`-direction,
       with both maneuvers having a magnitude of 1 mm/s
 
       .. code-block:: python # [py]
@@ -883,10 +921,33 @@ functions:
   - name: thrust_from_all_engines # [py]
     short_summary: "Creates settings for thrust acceleration using a single engine models."
     extended_summary: |
-      Creates settings for thrust acceleration by combining thryst from all engines defined in the body.. See the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/thrust_models.html>`_
+      Creates settings for thrust acceleration by combining thrust from all engines defined in the body. See the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/thrust_models.html>`_
       for more details on the definition of a thrust model in Tudat.
 
     returns:
         type: ThrustAccelerationSettings
         description: Thrust acceleration settings object.
 
+
+  # Yarkovsky acceleration
+  - name: yarkovskyAcceleration # [cpp]
+  - name: yarkovsky # [py]
+    short_summary: "Creates settings for the Yarkovsky acceleration."
+    extended_summary: |
+      Creates settings for the Yarkovsky acceleration, which is calculated based on Pérez-Hernández & Benet (2022). The acceleration is only
+      considered in the tangential direction and is proportional to:
+
+      .. math::
+
+         \mathbf{a}=A_{2} \cdot (\frac{r_{0}}{r_{S}})^{2}
+
+      where :math:`A_{2}` is the Yarkovsky parameter, :math:`r_{0} = 1` AU and :math:`r_{S}` is the heliocentric distance in AU.
+
+    parameters:
+      - name: yarkovsky_parameter # [py]
+        type: float # [py]
+        description: Value of the Yarkovsky parameter.
+
+    returns:
+        type: AccelerationSettings
+        description: Acceleration settings object.


### PR DESCRIPTION
Add accelerations that were exposed but not yet added to the API docs: polyhedron_gravity(), ring_gravity(), radiation_pressure() and yarkovsky(). Subject to change (e.g. more extensive documentation)

Also slightly modify docs for the tidal acceleration