### PR TITLE
Minor fixes to mathematical expressions and default arguments

### DIFF
--- a/docstrings/math/interpolators.yaml
+++ b/docstrings/math/interpolators.yaml
@@ -1,5 +1,5 @@
 extended_summary: |
-  Functions for performing numerical interpolation using various algorithms. More details on the usage of these functions is given in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/https://docs.tudat.space/en/latest/_src_user_guide/mathematics/interpolators.html>`_
+  Functions for performing numerical interpolation using various algorithms. More details on the usage of these functions is given in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/https://docs.tudat.space/en/latest/_src_user_guide/mathematics/interpolators.html>`.
 
 classes:
 
@@ -78,8 +78,8 @@ enums:
     short_summary: "Enumeration of types of behaviour to be used beyond the edges of the interpolation domain."
     extended_summary: |
      Enumeration of types of behaviour to be used beyond the edges of the interpolation domain. For independent variable
-     data in the range :math:`[t_{0}..t_{N}]`, this enum is used to define the behaviour of the interpolator at
-     :math:`t<t_{0}` and :math:`t>t_{N}
+     data in the range :math:`[t_{0}...t_{N}]`, this enum is used to define the behaviour of the interpolator at
+     :math:`t<t_{0}` and :math:`t>t_{N}`
 
     members:
       - name: throw_exception_at_boundary
@@ -91,8 +91,8 @@ enums:
       - name: use_boundary_value_with_warning
         description: Same as ``use_boundary_value``, but a warning is printed
       - name: extrapolate_at_boundary
-        description: The interpolation scheme is extended beyond the range `t_{0}...t_{N}` without any warning.
-          That is, the mathematical equation used to compute the value of :math:`x` in the range :math:`[t_{0}..t_{1}]`
+        description: The interpolation scheme is extended beyond the range :math:`t_{0}...t_{N}` without any warning.
+          That is, the mathematical equation used to compute the value of :math:`x` in the range :math:`[t_{0}...t_{1}]`
           is used without any checks for :math:`t<t_{0}`  (and equivalently for :math:`t>t_{N}`).
           Warning, using this setting can result in divergent/unrealistic behaviour
 
@@ -103,7 +103,7 @@ enums:
     short_summary: "Enumeration of types of behaviour to be used beyond the edges of the interpolation domain."
     extended_summary: |
       When the interpolation is performed, the interpolator scheme will typically start by finding the nearest neighbor of
-      the requested value of the independent variable :math:`t` in the data set :math:`[t_{0}..t_{N}]`.
+      the requested value of the independent variable :math:`t` in the data set :math:`[t_{0}...t_{N}]`.
       The choice of lookup scheme can have a significant influence on computational efficiency for large data sets and/or simple
       interpolation algorithms
 
@@ -114,7 +114,7 @@ enums:
           :math:`[t_{i}]` to find the nearest neighbor.
       - name: binary_search
         description: With this option, the algorithm uses a binary search algorithm to find the nearest neighbor, initially
-          starting with the full data range :math:`[t_{0}..t_{N}]`.
+          starting with the full data range :math:`[t_{0}...t_{N}]`.
 
   - name: LagrangeInterpolatorBoundaryHandling
     short_summary: "Enumeration of types of behaviour to be used close to the edges of the interpolation domain, for the Lagrange interpolator."
@@ -129,7 +129,7 @@ enums:
           full data set, and these cubic spline interpolators are used when an interpolation at :math:`t<t_{(m/2-1)}` or :math:`t<t_{N-(m/2)}` is called
 
       - name: lagrange_no_boundary_interpolation
-        description: he program will terminate with an error message when the Lagrange interpolator is interrogated beyond its valid range
+        description: The program will terminate with an error message when the Lagrange interpolator is interrogated beyond its valid range
 
 functions:
 
@@ -171,7 +171,7 @@ functions:
           variable input data when the interpolation scheme is called
 
       - name: boundary_interpolation # [py]
-        type: BoundaryInterpolationType = extrapolate_at_boundary_with_warning # [py]
+        type: BoundaryInterpolationType, default = extrapolate_at_boundary_with_warning # [py]
         description: Interpolator behaviour that is to be used beyond the upper and lower boundaries
           of the independent variable input data
 
@@ -196,7 +196,7 @@ functions:
           variable input data when the interpolation scheme is called
 
       - name: boundary_interpolation # [py]
-        type: BoundaryInterpolationType = extrapolate_at_boundary_with_warning # [py]
+        type: BoundaryInterpolationType, default = extrapolate_at_boundary_with_warning # [py]
         description: Interpolator behaviour that is to be used beyond the upper and lower boundaries
           of the independent variable input data
 
@@ -222,7 +222,7 @@ functions:
           variable input data when the interpolation scheme is called
 
       - name: boundary_interpolation # [py]
-        type: BoundaryInterpolationType = extrapolate_at_boundary_with_warning # [py]
+        type: BoundaryInterpolationType, default = extrapolate_at_boundary_with_warning # [py]
         description: Interpolator behaviour that is to be used beyond the upper and lower boundaries
           of the independent variable input data
 
@@ -242,13 +242,13 @@ functions:
 
       * The nearest lower neighbor of the data point :math:`t` at which the state :math:`\mathbf{x}` is to be interpolated is determined, and denoted :math:`t_{i}`.
       * An interpolating Lagrange polynomial is constructed from the consecutive data points :math:`[t_{i-(m/2-1)}...t_{i+m}]`
-      * This resulting interpolating polynomial is *only* used in the interval :math:`[t_{i}..t_{i+1}]`, to prevent `Runge's phenomenon <https://en.wikipedia.org/wiki/Runge%27s_phenomenon>`_.
+      * This resulting interpolating polynomial is *only* used in the interval :math:`[t_{i}...t_{i+1}]`, to prevent `Runge's phenomenon <https://en.wikipedia.org/wiki/Runge%27s_phenomenon>`_.
 
       For instance, if :math:`m=8` we use a :math:`7^{th}` order polynomial that interpolates a contiguous set of
       8 data points out of the full data set. Normally, the interpolating polynomial is only used between the
       :math:`4^{th}` and :math:`5^{th}` data point, where it will typically be of good accuracy. Consequently,
       a separate interpolating polynomial (using data over a span of :math:`m` consecutive points) is used for
-      each single interval :math:`[t_{i}..t_{i+1}]` (with the exception of the boundaries, see below).
+      each single interval :math:`[t_{i}...t_{i+1}]` (with the exception of the boundaries, see below).
 
       .. warning:: Issues can occur if the data point :math:`t` at which the interpolation is to be
                    performed is close to :math:`t_{0}` or :math:`t_{N}`. In those case, there is not sufficient
@@ -270,12 +270,12 @@ functions:
           variable input data when the interpolation scheme is called
 
       - name: boundary_interpolation # [py]
-        type: BoundaryInterpolationType = extrapolate_at_boundary_with_warning # [py]
+        type: BoundaryInterpolationType, default = extrapolate_at_boundary_with_warning # [py]
         description: Interpolator behaviour that is to be used beyond the upper and lower boundaries
           of the independent variable input data
 
       - name: lagrange_boundary_handling # [py]
-        type: LagrangeInterpolatorBoundaryHandling = lagrange_cubic_spline_boundary_interpolation # [py]
+        type: LagrangeInterpolatorBoundaryHandling, default = lagrange_cubic_spline_boundary_interpolation # [py]
         description: Interpolator behaviour that is to be used at the boundaries of the domain, where the
           regular algorithm cannot be executed.
 

--- a/docstrings/math/interpolators.yaml
+++ b/docstrings/math/interpolators.yaml
@@ -1,5 +1,5 @@
 extended_summary: |
-  Functions for performing numerical interpolation using various algorithms. More details on the usage of these functions is given in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/https://docs.tudat.space/en/latest/_src_user_guide/mathematics/interpolators.html>`.
+  Functions for performing numerical interpolation using various algorithms. More details on the usage of these functions is given in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/https://docs.tudat.space/en/latest/_src_user_guide/mathematics/interpolators.html>`_.
 
 classes:
 
@@ -161,7 +161,7 @@ functions:
     short_summary: "Function to create settings for piecewise constant interpolation."
     extended_summary: |
       Function to create settings for piecewise constant interpolation. If interpolator
-      is to return the value at :math:`t`, and :math:`t_{i}\le t \< t_{i+1}`, the interpolator
+      is to return the value at :math:`t`, and :math:`t_{i}\le t < t_{i+1}`, the interpolator
       returns :math:`\mathbf{x}_{i}`
 
     parameters:

--- a/docstrings/math/interpolators.yaml
+++ b/docstrings/math/interpolators.yaml
@@ -89,16 +89,19 @@ enums:
         description: The value :math:`\mathbf{x}_{0}` is returned for :math:`t<t_{0}`
           (and :math:`\mathbf{x}_{N}` if :math:`t>t_{N}`)
       - name: use_boundary_value_with_warning
-        description: Same as ``use_boundary_value``, but a warning is printed
+        description: Same as ``use_boundary_value``, but a warning is printed to the terminal
       - name: extrapolate_at_boundary
         description: The interpolation scheme is extended beyond the range :math:`t_{0}...t_{N}` without any warning.
           That is, the mathematical equation used to compute the value of :math:`x` in the range :math:`[t_{0}...t_{1}]`
           is used without any checks for :math:`t<t_{0}`  (and equivalently for :math:`t>t_{N}`).
           Warning, using this setting can result in divergent/unrealistic behaviour
-
       - name: extrapolate_at_boundary_with_warning
-        description: Same as ``extrapolate_at_boundary``, but with a warning printed.
-
+        description: Same as ``extrapolate_at_boundary``, but a warning is printed to the terminal
+      - name: use_nan_value
+        description: The program will return an interpolated value filled with NaN entries.
+      - name: use_nan_value_with_warning
+        description: Same as ``use_nan_value``, but a warning is printed to the terminal
+         
   - name: AvailableLookupScheme
     short_summary: "Enumeration of types of behaviour to be used beyond the edges of the interpolation domain."
     extended_summary: |
@@ -128,8 +131,18 @@ enums:
         description: A cubic-spline interpolator is created from the first and last :math:`\max(m/2-1,4)` data points of the
           full data set, and these cubic spline interpolators are used when an interpolation at :math:`t<t_{(m/2-1)}` or :math:`t<t_{N-(m/2)}` is called
 
+      - name: lagrange_cubic_spline_boundary_interpolation_with_warning
+        description: Same as ``lagrange_cubic_spline_boundary_interpolation``, but a warning is printed to the terminal
+
+
       - name: lagrange_no_boundary_interpolation
-        description: The program will terminate with an error message when the Lagrange interpolator is interrogated beyond its valid range
+        description: The program will terminate with an exception when the Lagrange interpolator is interrogated beyond its valid range
+
+      - name: lagrange_boundary_nan_interpolation
+        description: The program will return an interpolated value filled with NaN entries.
+
+      - name: lagrange_boundary_nan_interpolation_with_warning
+        description: Same as ``lagrange_boundary_nan_interpolation``, but a warning is printed to the terminal
 
 functions:
 

--- a/docstrings/math/interpolators.yaml
+++ b/docstrings/math/interpolators.yaml
@@ -143,7 +143,7 @@ functions:
 
     parameters:
       - name: lookup_scheme # [py]
-        type: AvailableLookupScheme, default=huntingAlgorithm # [py]
+        type: AvailableLookupScheme, default = hunting_algorithm # [py]
         description: Algorithm used to find the nearest neighbor in the independent
           variable input data when the interpolation scheme is called
 
@@ -166,7 +166,7 @@ functions:
 
     parameters:
       - name: lookup_scheme # [py]
-        type: AvailableLookupScheme, default = huntingalgorithm# [py]
+        type: AvailableLookupScheme, default = hunting_algorithm # [py]
         description: Algorithm used to find the nearest neighbor in the independent
           variable input data when the interpolation scheme is called
 
@@ -191,7 +191,7 @@ functions:
 
     parameters:
       - name: lookup_scheme # [py]
-        type: AvailableLookupScheme, default = huntingalgorithm# [py]
+        type: AvailableLookupScheme, default = hunting_algorithm # [py]
         description: Algorithm used to find the nearest neighbor in the independent
           variable input data when the interpolation scheme is called
 
@@ -217,7 +217,7 @@ functions:
 
     parameters:
       - name: lookup_scheme # [py]
-        type: AvailableLookupScheme, default = huntingalgorithm# [py]
+        type: AvailableLookupScheme, default = hunting_algorithm # [py]
         description: Algorithm used to find the nearest neighbor in the independent
           variable input data when the interpolation scheme is called
 
@@ -265,7 +265,7 @@ functions:
         description: Number of consecutive data points that are used to construct a single interpolating polynomial.
 
       - name: lookup_scheme # [py]
-        type: AvailableLookupScheme, default = huntingalgorithm # [py]
+        type: AvailableLookupScheme, default = hunting_algorithm # [py]
         description: Algorithm used to find the nearest neighbor in the independent
           variable input data when the interpolation scheme is called
 

--- a/docstrings/numerical_simulation/estimation_setup/observation.yaml
+++ b/docstrings/numerical_simulation/estimation_setup/observation.yaml
@@ -844,9 +844,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is None (unbiased observation)
 
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]
@@ -887,9 +887,9 @@ functions:
           Note that only one bias setting is applied to the n-way observable.
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
       type: :class:`NWayRangeObservationSettings`  # [py]
@@ -951,9 +951,9 @@ functions:
           Note that only one bias setting is applied to the n-way observable.
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
       type: :class:`NWayRangeObservationSettings`  # [py]
@@ -1023,9 +1023,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is none (unbiased observation)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]
@@ -1039,7 +1039,7 @@ functions:
     extended_summary: |
       Factory function for creating observation model settings of relative angular position type observables (as relative right ascension :math:`\Delta\alpha` and relative declination :math:`\Delta\delta`), 
       for a single link definition. The associated observation model creates an observable that is the difference of two :func:`~tudatpy.numerical_simulation.estimation_setup.observation.angular_position`
-      observables :math:`\left(\mathbf{h}_{_{\text{ang.pos.}}}\right)_{2}` and :math:`\mathbf{h}_{_{\text{ang.pos.}}}\right)_{1}`. 
+      observables :math:`\left(\mathbf{h}_{_{\text{ang.pos.}}}\right)_{2}` and :math:`\left(\mathbf{h}_{_{\text{ang.pos.}}}\right)_{1}`. 
       The resulting observable becomes :math:`\left(\mathbf{h}_{_{\text{ang.pos.}}}\right)_{2}-\left(\mathbf{h}_{_{\text{ang.pos.}}}\right)_{2}`
      
     parameters:
@@ -1063,9 +1063,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is none (unbiased observation)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]
@@ -1126,9 +1126,9 @@ functions:
           Settings for computing the receiver proper time rate :math:`\frac{d\tau}{dt}`, default is none (:math:`\frac{d\tau}{dt}=1`)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
       - name: normalized_with_speed_of_light # [py]
         type: bool, default = false # [py]
@@ -1194,9 +1194,9 @@ functions:
           Settings for computing the receiver proper time rate :math:`\frac{d\tau}{dt}`, default is none (:math:`\frac{d\tau}{dt}=1`)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
       - name: normalized_with_speed_of_light # [py]
         type: bool, default = false # [py]
@@ -1239,9 +1239,9 @@ functions:
           even if no bias is applied to the two-way observable, the constituent one-way observables may still be biased.
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`TwoWayDopplerObservationSettings`  # [py]
@@ -1285,9 +1285,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is none (unbiased observation)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]
@@ -1325,9 +1325,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is none (unbiased observation)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]
@@ -1389,9 +1389,9 @@ functions:
           Settings for the observation bias that is to be used for the observation, default is none (unbiased observation)
      
       - name: light_time_convergence_settings # [py]
-        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings`() # [py]
+        type: :class:`LightTimeConvergenceCriteria`, default = :func:`light_time_convergence_settings` # [py]
         description: |
-          Settings for convergence of the light-time (default settings defined in :func:`light_time_convergence_settings`)
+          Settings for convergence of the light-time 
 
     returns:
         type: :class:`ObservationSettings`  # [py]

--- a/docstrings/numerical_simulation/propagation_setup/integrator.yaml
+++ b/docstrings/numerical_simulation/propagation_setup/integrator.yaml
@@ -288,7 +288,7 @@ functions:
         description: Value of relative error tolerance :math:`\epsilon_{r}`.  
       - name: absolute_error_tolerance
         type: float
-        description: Value of relative error tolerance :math:`\epsilon_{a}`.  
+        description: Value of absolute error tolerance :math:`\epsilon_{a}`.  
       - name: safety_factor
         type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
@@ -317,12 +317,12 @@ functions:
       If the size of the tolerances used as input differ from one another, or differ from the size of the state vector, an exception is thrown
       
     parameters:
-      - name: absolute_error_tolerance
+      - name: relative_error_tolerance
         type: numpy.ndarray[numpy.float64[m, n]]
         description: Values of relative error tolerance :math:`\boldsymbol{\epsilon}_{r}`.  
       - name: absolute_error_tolerance
         type: numpy.ndarray[numpy.float64[m, n]]
-        description: Values of relative error tolerance :math:`\boldsymbol{\epsilon_{a}`. 
+        description: Values of absolute error tolerance :math:`\boldsymbol{\epsilon}_{a}`. 
       - name: safety_factor
         type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 

--- a/docstrings/numerical_simulation/propagation_setup/integrator.yaml
+++ b/docstrings/numerical_simulation/propagation_setup/integrator.yaml
@@ -97,7 +97,7 @@ enums:
 #######################################################################
 
   - name: MinimumIntegrationTimeStepHandling
-    short_summary: Enumeration defining possible behaviours when :math:`\Delta t_{rec}<\Delta t_{min}`. in step-size control (e.g. recommended time step is smaller than minimum time step)
+    short_summary: Enumeration defining possible behaviours when :math:`\Delta t_{rec}<\Delta t_{\min}`. in step-size control (e.g. recommended time step is smaller than minimum time step)
 
     members:
       - name: throw_exception_below_minimum
@@ -225,7 +225,7 @@ functions:
     extended_summary: |
       Factory function to create settings step size validation in a variable step-size integrator. The validation
       model takes the proposed new step size  :math:`\Delta t_{rec}` as input, and checks if it meets predefined conditions, specifically
-      whether the proposed time step falls in a given predefined range :math:`[\Delta t_{\min}, \Delta t_{max}]`.
+      whether the proposed time step falls in a given predefined range :math:`[\Delta t_{\min}, \Delta t_{\max}]`.
       This function also provides the option of handling recommended step sizes below :math:`\Delta t_{\min}` in various ways,
       and control on how to deal with recommend Inf/NaN step sizes.
     
@@ -256,7 +256,7 @@ functions:
     short_summary: "Creates settings for integrator step-size control, using element-wise analysis for the propagated states."
     extended_summary: |
       Function to create settings for integrator step-size control, using element-wise analysis for the propagated states. For a propagated
-      state with :math:`\mathbf{x}` with entries :math:`x_{i}`, and an estimate :math:`\boldsymbol{\epsilon}` for the current local error, the following
+      state :math:`\mathbf{x}` with entries :math:`x_{i}`, and an estimate :math:`\boldsymbol{\epsilon}` for the current local error, the following
       algorithm is performed per element :math:`i` to calculate the required error :math:`\epsilon_{i,req}` on this element:
       
       .. math::
@@ -278,8 +278,8 @@ functions:
       the proposed increase/decrease to the step size is constrained to this limit value. That is, if :math:`\Delta t_{rec.}/\Delta t` proposed by the algorithm is
       1000, and the ``maximum_factor_increase`` input is equal to 20, the algorithm will use :math:`\Delta t_{rec.}/\Delta t=20` in what follows. 
       
-      For cases where :math:`\bar{\Delta t_{rec.}}/\Delta t`<1`, the step is recommended to be recomputed with the new proposed step size (e.g. the current step 
-      is not accepted, and will be re-attempted with a smaller step size). For cases where :math:`\bar{\Delta t_{rec.}}/\Delta t`>1`, the step is accepted, and 
+      For cases where :math:`\bar{\Delta t_{rec.}}/\Delta t < 1`, the step is recommended to be recomputed with the new proposed step size (e.g. the current step 
+      is not accepted, and will be re-attempted with a smaller step size). For cases where :math:`\bar{\Delta t_{rec.}}/\Delta t > 1`, the step is accepted, and 
       the next step will be performed with the new, higher, step size.
       
     parameters:

--- a/docstrings/numerical_simulation/propagation_setup/integrator.yaml
+++ b/docstrings/numerical_simulation/propagation_setup/integrator.yaml
@@ -79,9 +79,9 @@ enums:
 
     members:
       - name: lower # [py]
-        description: For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`min(p,q)`
+        description: For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\min(p,q)`
       - name: higher # [py]
-        description: For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`max(p,q)`
+        description: For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\max(p,q)`
   
   #######################################################################
         
@@ -103,12 +103,12 @@ enums:
       - name: throw_exception_below_minimum
         description: Exception is throw, and propagation is terminated
       - name: set_to_minimum_step_silently
-        description: The final time step is set to :math:`\Delta t=\Delta t_{min}`, violating requirements of step-size control algorithm, without any message to user"
+        description: The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, without any message to user"
 
       - name: set_to_minimum_step_single_warning
-        description: The final time step is set to :math:`\Delta t=\Delta t_{min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal the first time this happens during a propagation"
+        description: The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal the first time this happens during a propagation"
       - name: set_to_minimum_step_every_time_warning
-        description: The final time step is set to :math:`\Delta t=\Delta t_{min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal every time this happens during a propagation"
+        description: The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal every time this happens during a propagation"
 
   #######################################################################
   #######################################################################
@@ -225,20 +225,20 @@ functions:
     extended_summary: |
       Factory function to create settings step size validation in a variable step-size integrator. The validation
       model takes the proposed new step size  :math:`\Delta t_{rec}` as input, and checks if it meets predefined conditions, specifically
-      whether the proposed time step falls in a given predefined range :math:`[\Delta t_{min}, \Delta t_{max}]`.
-      This function also provides the option of handling recommended step sizes below :math:`\Delta t_{min}` in various ways,
+      whether the proposed time step falls in a given predefined range :math:`[\Delta t_{\min}, \Delta t_{max}]`.
+      This function also provides the option of handling recommended step sizes below :math:`\Delta t_{\min}` in various ways,
       and control on how to deal with recommend Inf/NaN step sizes.
     
     parameters:
       - name: minimum_step
         type: float
-        description: Value of minimum permitted time step :math:`\Delta t_{min}`.  
+        description: Value of minimum permitted time step :math:`\Delta t_{\min}`.  
       - name: maximum_step
         type: float
-        description: Value of maximum permitted time step :math:`\Delta t_{max}`.  
+        description: Value of maximum permitted time step :math:`\Delta t_{\max}`.  
       - name: minimum_step_size_handling
         type: MinimumIntegrationTimeStepHandling, default = throw_exception_below_minimum
-        description: Entry defining the behaviour when :math:`\Delta t_{rec}<\Delta t_{min}`.  
+        description: Entry defining the behaviour when :math:`\Delta t_{rec}<\Delta t_{\min}`.  
       - name: accept_infinity_step
         type: bool, default = False
         description: "Entry defining whether to accept a step size of infinity (if False, exception is throw in such cases)"  
@@ -290,7 +290,7 @@ functions:
         type: float
         description: Value of relative error tolerance :math:`\epsilon_{a}`.  
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1
@@ -324,7 +324,7 @@ functions:
         type: numpy.ndarray[numpy.float64[m, n]]
         description: Values of relative error tolerance :math:`\boldsymbol{\epsilon_{a}`. 
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1
@@ -366,7 +366,7 @@ functions:
         type: float
         description: Value of absolute error tolerance :math:`\epsilon_{a}`.  
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1
@@ -403,7 +403,7 @@ functions:
         type: numpy.ndarray[numpy.float64[m, 1]]
         description: Values of absolute error tolerance :math:`\boldsymbol{\epsilon}_{a}`.  
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1
@@ -441,7 +441,7 @@ functions:
         type: float
         description: Value of absolute error tolerance :math:`\epsilon_{a}`.  
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1
@@ -475,7 +475,7 @@ functions:
         type: numpy.ndarray[numpy.float64[m, 1]]
         description: Values of absolute error tolerance :math:`\boldsymbol{\epsilon}_{a}`.  
       - name: safety_factor
-        type: float. default = 0.8
+        type: float, default = 0.8
         description: Safety factor :math:`K` for step size control 
       - name: minimum_factor_increase
         type: float, default = 0.1


### PR DESCRIPTION
Fixing minor typos in mathematical expressions, make default argument consistent to link to type of argument.